### PR TITLE
fix: wrong import  for '../sfcc-globals'

### DIFF
--- a/lib/sfra/index.js
+++ b/lib/sfra/index.js
@@ -1,4 +1,4 @@
-const sfccGlobals = require('../sfccGlobals')
+const sfccGlobals = require('../sfcc-globals')
 
 module.exports = {
   extends: [


### PR DESCRIPTION
I noticed the require path for `sfccGlobals` was still pointing to `../sfccGlobals` instead of `../sfcc-globals`, which was causing a module resolution error. I've updated it to match the actual filename. 
Thanks for maintaining this package!