### PR TITLE
feat: add built-in sitegenesis plugin with no-global-require rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ export default defineConfig(
 
 ---
 
+## Built-in Plugin: `sitegenesis`
+
+This package ships a built-in ESLint plugin with rules ported from [`eslint-plugin-sitegenesis`](https://www.npmjs.com/package/eslint-plugin-sitegenesis) and adapted for ESLint 9+. The plugin is automatically registered in the recommended config.
+
+The plugin is also exported for direct use in custom configs:
+
+```js
+import { defineConfig } from "eslint/config"
+import sfcc, { sitegenesis } from "@jenssimon/eslint-config-sfcc"
+
+export default defineConfig(sfcc.configs.recommended, {
+  plugins: { sitegenesis },
+  rules: {
+    "sitegenesis/no-global-require": "error",
+  },
+})
+```
+
+### Rules
+
+| Rule                            | Description                                                                                                                                              | Default |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `sitegenesis/no-global-require` | Disallows top-level `require()` calls in controller files when not every route function uses them. Only applies to files under `cartridge/controllers/`. | `error` |
+
+---
+
 ## Migrating from v4
 
 This is a major release with breaking changes.
@@ -60,13 +86,13 @@ The previous version extended [`@jenssimon/eslint-config-base`](https://github.c
 The old `eslint-plugin-es5` has been replaced by [`eslint-plugin-es`](https://github.com/mysticatea/eslint-plugin-es). Rules have been mapped accordingly.
 
 **No more SiteGenesis / SFRA configs**
-The `sfra` and `sfra-storefront` configurations have been removed. `eslint-plugin-sitegenesis` is no longer used. These configurations were specific to SFRA and SiteGenesis and are not part of this general-purpose SFCC config.
+The `sfra` and `sfra-storefront` configurations have been removed. These configurations were specific to SFRA and SiteGenesis and are not part of this general-purpose SFCC config. The external `eslint-plugin-sitegenesis` dependency is no longer used — the `sitegenesis/no-global-require` rule is now built into this package and enabled automatically.
 
 ### Migration steps
 
 1. Replace `.eslintrc.*` with `eslint.config.js`
 2. Update the package name and import (see [Usage](#recommended-config) above)
-3. Remove [`@jenssimon/eslint-config-base`](https://github.com/jenssimon/eslint-config-base), [`eslint-plugin-es5`](https://github.com/nkt/eslint-plugin-es5), and [`eslint-plugin-sitegenesis`](https://www.npmjs.com/package/eslint-plugin-sitegenesis) from your dependencies
+3. Remove [`@jenssimon/eslint-config-base`](https://github.com/jenssimon/eslint-config-base), [`eslint-plugin-es5`](https://github.com/nkt/eslint-plugin-es5), and [`eslint-plugin-sitegenesis`](https://www.npmjs.com/package/eslint-plugin-sitegenesis) from your dependencies — the `sitegenesis/no-global-require` rule is now built in
 4. Add any formatting rules you need directly to your own `eslint.config.js`
 
 ## Development

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -4,6 +4,7 @@ import { fixupPluginRules } from "@eslint/compat"
 import es from "eslint-plugin-es"
 import globals from "globals"
 
+import sitegenesis from "../plugins/sitegenesis/index.js"
 import rules from "../rules/index.js"
 import sfccGlobals from "../sfcc-globals.js"
 
@@ -41,6 +42,7 @@ export function createRecommendedConfig(options: RecommendedConfigOptions = {}):
       },
       plugins: {
         es: fixupPluginRules(es as never),
+        sitegenesis,
       },
       rules,
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,21 @@
 import type { Linter } from "eslint"
 
 import recommended, { createRecommendedConfig } from "./configs/recommended.js"
+import sitegenesis from "./plugins/sitegenesis/index.js"
 
 const configs: { recommended: Linter.Config[] } = {
   recommended,
 }
 
-const sfcc: { configs: typeof configs } = {
-  configs,
+const plugins = {
+  sitegenesis,
 }
 
-export { configs, recommended }
+const sfcc: { configs: typeof configs; plugins: typeof plugins } = {
+  configs,
+  plugins,
+}
+
+export { configs, plugins, recommended, sitegenesis }
 export { createRecommendedConfig }
 export default sfcc

--- a/src/plugins/sitegenesis/index.ts
+++ b/src/plugins/sitegenesis/index.ts
@@ -1,0 +1,9 @@
+import noGlobalRequire from "./no-global-require.js"
+
+const sitegenesis = {
+  rules: {
+    "no-global-require": noGlobalRequire,
+  },
+}
+
+export default sitegenesis

--- a/src/plugins/sitegenesis/no-global-require.ts
+++ b/src/plugins/sitegenesis/no-global-require.ts
@@ -1,0 +1,123 @@
+import type { Rule, Scope } from "eslint"
+
+type RequireUsage = {
+  node: unknown
+  variable: Scope.Variable
+  functionScopes: Set<unknown>
+  usedGlobally: boolean
+}
+
+function isRequireInitializer(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+
+  const node = value as {
+    type?: string
+    callee?: { type?: string; name?: string }
+  }
+
+  return (
+    node.type === "CallExpression" &&
+    node.callee?.type === "Identifier" &&
+    node.callee.name === "require"
+  )
+}
+
+const noGlobalRequire: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Disallow global require usage unless every function depends on it.",
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      moveInsideRoute: '"{{name}}" should be declared inside route',
+    },
+  },
+  create: (context) => {
+    const normalizedFilename = context.filename.replaceAll("\\", "/")
+    if (!normalizedFilename.includes("/cartridge/controllers/")) {
+      return {}
+    }
+
+    let routeCount = 0
+    const requires: Record<string, RequireUsage> = {}
+
+    return {
+      FunctionExpression() {
+        routeCount += 1
+      },
+      FunctionDeclaration() {
+        routeCount += 1
+      },
+      Program(node) {
+        const topScope = context.sourceCode.getScope(node)
+        const candidateScopes = context.sourceCode.scopeManager.scopes.filter(
+          (scope) => scope === topScope || scope.upper === topScope,
+        )
+
+        for (const scope of candidateScopes) {
+          for (const variable of scope.variables) {
+            if (variable.name === "arguments") {
+              continue
+            }
+
+            const definition = variable.defs[0]
+            if (!definition) {
+              continue
+            }
+
+            const initNode = "init" in definition.node ? definition.node.init : undefined
+            if (!isRequireInitializer(initNode)) {
+              continue
+            }
+
+            const identifier = variable.identifiers[0]
+            if (!identifier) {
+              continue
+            }
+
+            requires[variable.name] = {
+              node: identifier,
+              variable,
+              functionScopes: new Set(),
+              usedGlobally: false,
+            }
+          }
+        }
+      },
+      "Program:exit"() {
+        const requiredFunctionUsages = routeCount === 0 ? 1 : routeCount
+
+        for (const [name, usage] of Object.entries(requires)) {
+          for (const reference of usage.variable.references) {
+            if (reference.init) {
+              continue
+            }
+
+            if (reference.from.type === "global" || reference.from.block.type === "Program") {
+              usage.usedGlobally = true
+              continue
+            }
+
+            if (reference.from.type === "function") {
+              usage.functionScopes.add(reference.from.block)
+            }
+          }
+
+          if (usage.functionScopes.size < requiredFunctionUsages && !usage.usedGlobally) {
+            context.report({
+              node: usage.node as Rule.Node,
+              messageId: "moveInsideRoute",
+              data: { name },
+            })
+          }
+        }
+      },
+    }
+  },
+}
+
+export default noGlobalRequire

--- a/src/plugins/sitegenesis/no-global-require.ts
+++ b/src/plugins/sitegenesis/no-global-require.ts
@@ -42,54 +42,64 @@ const noGlobalRequire: Rule.RuleModule = {
       return {}
     }
 
+    // The program-level scope: in CommonJS the module wrapper is a child of the
+    // global scope, so top-level variables live in globalScope.childScopes[0].
+    let programScope: Scope.Scope | null = null
     let routeCount = 0
     const requires: Record<string, RequireUsage> = {}
 
     return {
-      FunctionExpression() {
-        routeCount += 1
-      },
-      FunctionDeclaration() {
-        routeCount += 1
-      },
       Program(node) {
-        const topScope = context.sourceCode.getScope(node)
-        const candidateScopes = context.sourceCode.scopeManager.scopes.filter(
-          (scope) => scope === topScope || scope.upper === topScope,
-        )
+        const globalScope = context.sourceCode.getScope(node)
+        programScope = globalScope.childScopes[0] ?? globalScope
 
-        for (const scope of candidateScopes) {
-          for (const variable of scope.variables) {
-            if (variable.name === "arguments") {
-              continue
-            }
+        // Only collect variables declared at the program/module top level.
+        for (const variable of programScope.variables) {
+          if (variable.name === "arguments") {
+            continue
+          }
 
-            const definition = variable.defs[0]
-            if (!definition) {
-              continue
-            }
+          const definition = variable.defs[0]
+          if (!definition) {
+            continue
+          }
 
-            const initNode = "init" in definition.node ? definition.node.init : undefined
-            if (!isRequireInitializer(initNode)) {
-              continue
-            }
+          const initNode = "init" in definition.node ? definition.node.init : undefined
+          if (!isRequireInitializer(initNode)) {
+            continue
+          }
 
-            const identifier = variable.identifiers[0]
-            if (!identifier) {
-              continue
-            }
+          const identifier = variable.identifiers[0]
+          if (!identifier) {
+            continue
+          }
 
-            requires[variable.name] = {
-              node: identifier,
-              variable,
-              functionScopes: new Set(),
-              usedGlobally: false,
-            }
+          requires[variable.name] = {
+            node: identifier,
+            variable,
+            functionScopes: new Set(),
+            usedGlobally: false,
           }
         }
       },
+      FunctionExpression(node) {
+        // Count only top-level route functions, not nested helpers.
+        const scope = context.sourceCode.getScope(node)
+        if (scope.upper === programScope) {
+          routeCount += 1
+        }
+      },
+      FunctionDeclaration(node) {
+        const scope = context.sourceCode.getScope(node)
+        if (scope.upper === programScope) {
+          routeCount += 1
+        }
+      },
       "Program:exit"() {
-        const requiredFunctionUsages = routeCount === 0 ? 1 : routeCount
+        // Nothing to report when there are no route functions.
+        if (routeCount === 0) {
+          return
+        }
 
         for (const [name, usage] of Object.entries(requires)) {
           for (const reference of usage.variable.references) {
@@ -107,7 +117,7 @@ const noGlobalRequire: Rule.RuleModule = {
             }
           }
 
-          if (usage.functionScopes.size < requiredFunctionUsages && !usage.usedGlobally) {
+          if (usage.functionScopes.size < routeCount && !usage.usedGlobally) {
             context.report({
               node: usage.node as Rule.Node,
               messageId: "moveInsideRoute",

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -2,6 +2,7 @@ import type { Linter } from "eslint"
 
 import core from "./core.js"
 import es from "./es.js"
+import sitegenesis from "./sitegenesis.js"
 import sonarjs from "./sonarjs.js"
 import typescriptEslint from "./typescript-eslint.js"
 import unicorn from "./unicorn.js"
@@ -12,6 +13,7 @@ const rules: Linter.RulesRecord = {
   ...sonarjs,
   ...typescriptEslint,
   ...es,
+  ...sitegenesis,
 }
 
 export default rules

--- a/src/rules/sitegenesis.ts
+++ b/src/rules/sitegenesis.ts
@@ -1,0 +1,7 @@
+import type { Linter } from "eslint"
+
+const sitegenesis: Linter.RulesRecord = {
+  "sitegenesis/no-global-require": "error",
+}
+
+export default sitegenesis

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,12 @@
 import { expect, test } from "vite-plus/test"
 
-import sfcc, { configs, createRecommendedConfig, recommended } from "../src/index.js"
+import sfcc, {
+  configs,
+  createRecommendedConfig,
+  plugins,
+  recommended,
+  sitegenesis,
+} from "../src/index.js"
 
 test("exports a recommended flat config", () => {
   expect(Array.isArray(recommended)).toBe(true)
@@ -24,4 +30,13 @@ test("exports createRecommendedConfig helper", () => {
 test("accepts cartridgesDir with trailing slash", () => {
   const createdConfig = createRecommendedConfig({ cartridgesDir: "cartridges/" })
   expect(createdConfig).toEqual(recommended)
+})
+
+test("exports sitegenesis plugin", () => {
+  expect(sitegenesis).toBe(plugins.sitegenesis)
+})
+
+test("exposes plugins on default export", () => {
+  expect(sfcc.plugins).toBe(plugins)
+  expect(sfcc.plugins.sitegenesis).toBe(sitegenesis)
 })

--- a/tests/sitegenesis-no-global-require.test.ts
+++ b/tests/sitegenesis-no-global-require.test.ts
@@ -1,0 +1,79 @@
+import { Linter } from "eslint"
+import { expect, test } from "vite-plus/test"
+
+import { recommended } from "../src/index.js"
+
+function lint(code: string, filename: string): Linter.LintMessage[] {
+  const linter = new Linter()
+  return linter.verify(code, recommended, { filename })
+}
+
+test("global require used only in some functions is reported", () => {
+  const messages = lint(
+    `
+      var URLUtils = require("dw/web/URLUtils")
+      function routeA() {
+        return URLUtils.url("Home-Show")
+      }
+      function routeB() {
+        return "ok"
+      }
+    `,
+    "cartridges/app_sfra/cartridge/controllers/Home.js",
+  )
+
+  expect(messages.some((m) => m.ruleId === "sitegenesis/no-global-require")).toBe(true)
+})
+
+test("global require used in every function is allowed", () => {
+  const messages = lint(
+    `
+      var URLUtils = require("dw/web/URLUtils")
+      function routeA() {
+        return URLUtils.url("Home-Show")
+      }
+      function routeB() {
+        return URLUtils.url("Search-Show")
+      }
+    `,
+    "cartridges/app_sfra/cartridge/controllers/Home.js",
+  )
+
+  expect(messages.filter((m) => m.severity > 0)).toHaveLength(0)
+})
+
+test("global require with global usage is allowed", () => {
+  const messages = lint(
+    `
+      var URLUtils = require("dw/web/URLUtils")
+      var homeUrl = URLUtils.url("Home-Show")
+      function routeA() {
+        return homeUrl
+      }
+      function routeB() {
+        return "ok"
+      }
+    `,
+    "cartridges/app_sfra/cartridge/controllers/Home.js",
+  )
+
+  expect(messages.filter((m) => m.severity > 0)).toHaveLength(0)
+})
+
+test("global require without functions is ignored outside controllers", () => {
+  const messages = lint(
+    `var URLUtils = require("dw/web/URLUtils")`,
+    "cartridges/app_sfra/cartridge/scripts/helpers/url.js",
+  )
+
+  expect(messages.some((m) => m.ruleId === "sitegenesis/no-global-require")).toBe(false)
+})
+
+test("global require is ignored in models files", () => {
+  const messages = lint(
+    `var URLUtils = require("dw/web/URLUtils")`,
+    "cartridges/app_sfra/cartridge/models/product.js",
+  )
+
+  expect(messages.some((m) => m.ruleId === "sitegenesis/no-global-require")).toBe(false)
+})

--- a/tests/sitegenesis-no-global-require.test.ts
+++ b/tests/sitegenesis-no-global-require.test.ts
@@ -77,3 +77,20 @@ test("global require is ignored in models files", () => {
 
   expect(messages.some((m) => m.ruleId === "sitegenesis/no-global-require")).toBe(false)
 })
+
+test("require declared inside a route function is allowed", () => {
+  const messages = lint(
+    `
+      function routeA() {
+        var URLUtils = require("dw/web/URLUtils")
+        return URLUtils.url("Home-Show")
+      }
+      function routeB() {
+        return "ok"
+      }
+    `,
+    "cartridges/app_sfra/cartridge/controllers/Home.js",
+  )
+
+  expect(messages.some((m) => m.ruleId === "sitegenesis/no-global-require")).toBe(false)
+})


### PR DESCRIPTION
Ports sitegenesis/no-global-require from eslint-plugin-sitegenesis and adapts it for ESLint 9+ (Flat Config, modern scope APIs). The rule is automatically enabled in the recommended config and only applies to files under cartridge/controllers/.

The plugin is also exported publicly for use in custom configs:
- named export `sitegenesis` (plugin object)
- named export `plugins` (map of all built-in plugins)
- `sfcc.plugins.sitegenesis` on the default export